### PR TITLE
(SIMP-335) Proper update to version 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.5.0
+
+- Implement instances for sshkey (only for non-hashed entries)
+
+## 2.4.0
+
+- Add sshd_config_match type and provider (#GH 5)
+- Purge multiple array entries in ssh_config provider (GH #12)
+
+## 2.3.0
+
+- Add sshkey provider (GH #13)
+- sshd_config: munge condition parameter
+- Improve test setup
+- Get rid of Gemfile.lock
+- Improve README badges
+
 ## 2.2.2
 
 - Properly insert values after commented out entry if case doesn't match (GH #6)

--- a/Gemfile
+++ b/Gemfile
@@ -18,20 +18,29 @@ else
   rbaugversion = ['~> 0.3']
 end
 gem 'ruby-augeas', rbaugversion
+gem 'simp-rake-helpers'
 
-group :development do
-  gem 'puppet-lint'
-  gem 'puppet-syntax'
-  gem 'puppetlabs_spec_helper', '>= 0.4.1'
-  gem 'rake'
-  gem 'rspec-puppet', :git => 'https://github.com/rodjek/rspec-puppet.git', :ref => '544b168'
-  gem 'simplecov'
-  gem 'yard'
-  gem 'redcarpet', '~> 2.0'
-  gem 'pry'
-  gem 'coveralls'
-  gem 'beaker', :require => false, :git => 'https://github.com/puppetlabs/beaker', :ref => 'dbac20fe9'
-  gem 'beaker-rspec', :require => false
-  gem 'vagrant-wrapper', :require => false
-  gem 'simp-rake-helpers',       :require => false
+group :development, :unit_tests do
+  gem 'rake',                                              :require => false
+  gem 'rspec', '< 3.2',                                    :require => false if RUBY_VERSION =~ /^1\.8/
+  gem 'rspec-puppet',                                      :require => false
+  gem 'puppetlabs_spec_helper',                            :require => false
+  gem 'metadata-json-lint',                                :require => false
+  gem 'puppet-lint',                                       :require => false
+  gem 'puppet-lint-unquoted_string-check',                 :require => false
+  gem 'puppet-lint-empty_string-check',                    :require => false
+  gem 'puppet-lint-spaceship_operator_without_tag-check',  :require => false
+  gem 'puppet-lint-variable_contains_upcase',              :require => false
+  gem 'puppet-lint-absolute_classname-check',              :require => false
+  gem 'puppet-lint-undef_in_function-check',               :require => false
+  gem 'puppet-lint-leading_zero-check',                    :require => false
+  gem 'puppet-lint-trailing_comma-check',                  :require => false
+  gem 'puppet-lint-file_ensure-check',                     :require => false
+  gem 'puppet-lint-version_comparison-check',              :require => false
+  gem 'rspec-puppet-facts',                                :require => false
+
+  gem 'coveralls',                                         :require => false unless RUBY_VERSION =~ /^1\.8/
+  gem 'simplecov', '~> 0.7.0',                             :require => false
+  gem 'yard',                                              :require => false
+  gem 'redcarpet', '~> 2.0',                               :require => false
 end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-[![Puppet Forge](http://img.shields.io/puppetforge/v/herculesteam/augeasproviders_ssh.svg)](https://forge.puppetlabs.com/herculesteam/augeasproviders_ssh)
-[![Build Status](https://travis-ci.org/hercules-team/augeasproviders_ssh.svg?branch=master)](https://travis-ci.org/hercules-team/augeasproviders_ssh)
+[![Puppet Forge Version](http://img.shields.io/puppetforge/v/herculesteam/augeasproviders_ssh.svg)](https://forge.puppetlabs.com/herculesteam/augeasproviders_ssh)
+[![Puppet Forge Downloads](http://img.shields.io/puppetforge/dt/herculesteam/augeasproviders_ssh.svg)](https://forge.puppetlabs.com/herculesteam/augeasproviders_ssh)
+[![Puppet Forge Endorsement](https://img.shields.io/puppetforge/e/herculesteam/augeasproviders_ssh.svg)](https://forge.puppetlabs.com/herculesteam/augeasproviders_ssh)
+[![Build Status](https://img.shields.io/travis/hercules-team/augeasproviders_ssh/master.svg)](https://travis-ci.org/hercules-team/augeasproviders_ssh)
 [![Coverage Status](https://img.shields.io/coveralls/hercules-team/augeasproviders_ssh.svg)](https://coveralls.io/r/hercules-team/augeasproviders_ssh)
+[![Gemnasium](https://img.shields.io/gemnasium/hercules-team/augeasproviders_ssh.svg)](https://gemnasium.com/hercules-team/augeasproviders_ssh)
 
 
 # ssh: type/provider for ssh files for Puppet
@@ -53,7 +56,9 @@ case-insensitive keys     | no      | **yes** | **yes** | **yes** |
 **PROVIDERS**             |
 ssh\_config               | **yes** | **yes** | **yes** | **yes** |
 sshd\_config              | **yes** | **yes** | **yes** | **yes** |
+sshd\_config\_match       | **yes** | **yes** | **yes** | **yes** |
 sshd\_config\_subsystem   | **yes** | **yes** | **yes** | **yes** |
+sshkey                    | **yes** | **yes** | **yes** | **yes** |
 
 ## Documentation and examples
 
@@ -189,6 +194,39 @@ Type documentation can be generated with `puppet doc -r type` or viewed on the
       target => "/etc/ssh/another_sshd_config",
     }
 
+### sshd_config_match provider
+
+#### manage entry
+
+    sshd_config_match { "Host *.example.net":
+      ensure => present,
+    }
+
+#### manage entry with position
+
+    sshd_config_match { "Host *.example.net":
+      ensure   => present,
+      position => "before first match",
+    }
+
+    sshd_config_match { "User foo":
+      ensure   => present,
+      position => "after Host *.example.net",
+    }
+
+#### delete entry
+
+    sshd_config_match { "User foo Host *.example.net":
+      ensure => absent,
+    }
+
+#### manage entry in another sshd_config location
+
+    sshd_config_match { "Host *.example.net":
+      ensure => present,
+      target => "/etc/ssh/another_sshd_config",
+    }
+
 ### sshd_config_subsystem provider
 
 #### manage entry
@@ -210,6 +248,58 @@ Type documentation can be generated with `puppet doc -r type` or viewed on the
       ensure  => present,
       command => "/usr/lib/openssh/sftp-server",
       target  => "/etc/ssh/another_sshd_config",
+    }
+
+### sshkey provider
+
+#### manage entry
+
+    sshkey { "foo.example.com":
+      ensure  => present,
+      type    => "ssh-rsa",
+      key     => "AAADEADMEAT",
+    }
+
+#### manage entry with aliases
+
+    sshkey { "foo.example.com":
+      ensure       => present,
+      type         => "ssh-rsa",
+      key          => "AAADEADMEAT",
+      host_aliases => [ 'foo', '192.168.0.1' ],
+    }
+
+#### manage hashed entry
+
+    sshkey { "foo.example.com":
+      ensure        => present,
+      type          => "ssh-rsa",
+      key           => "AAADEADMEAT",
+      hash_hostname => true,
+    }
+
+#### hash existing entry
+
+    sshkey { "foo.example.com":
+      ensure        => hashed,
+      type          => "ssh-rsa",
+      key           => "AAADEADMEAT",
+      hash_hostname => true,
+    }
+
+#### delete entry
+
+    sshkey { "foo.example.com":
+      ensure => absent,
+    }
+
+#### manage entry in another ssh_known_hosts location
+
+    sshkey { "foo.example.com":
+      ensure  => present,
+      type    => "ssh-rsa",
+      key     => "AAADEADMEAT",
+      target  => "/root/.ssh/known_hosts",
     }
 
 ## Issues

--- a/build/pupmod-augeasproviders_ssh.spec
+++ b/build/pupmod-augeasproviders_ssh.spec
@@ -2,7 +2,7 @@
 
 Summary: SSH Augeas-based providers for Puppet
 Name: pupmod-augeasproviders_ssh
-Version: 2.0.1
+Version: 2.5.0
 Release: 0
 License: Apache License, 2.0
 Group: Applications/System
@@ -50,5 +50,10 @@ mkdir -p %{buildroot}/%{prefix}/%{mod_name}
 # Post uninstall stuff
 
 %changelog
+* Sat Aug 01 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.5.0-0
+- Updated to the latest %{mod_name}
+- Reverted all of the patches that we needed to make since they appear to have
+  fixed the issues that we found.
+
 * Wed Feb 18 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.0.1-0
 - First release of %{mod_name} from Team Hercules

--- a/lib/puppet/provider/ssh_config/augeas.rb
+++ b/lib/puppet/provider/ssh_config/augeas.rb
@@ -68,6 +68,8 @@ Puppet::Type.type(:ssh_config).provide(:augeas, :parent => Puppet::Type.type(:au
   def self.set_value(aug, base, path, label, value)
     if label =~ /Ciphers|SendEnv|MACs/i
       aug.rm("#{path}/*")
+      # In case there is more than one entry, keep only the first one
+      aug.rm("#{path}[position() != 1]")
       count = 0
       value.each do |v|
         count += 1

--- a/lib/puppet/type/sshd_config_subsystem.rb
+++ b/lib/puppet/type/sshd_config_subsystem.rb
@@ -8,16 +8,6 @@ Puppet::Type.newtype(:sshd_config_subsystem) do
 
   ensurable
 
-  def initialize(args)
-    super(args)
-
-    if self[:notify] then
-      self[:notify] += ['Service[sshd]']
-    else
-      self[:notify] = ['Service[sshd]']
-    end
-  end
-
   newparam(:name) do
     desc "The name of the subsystem to set."
     isnamevar

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "herculesteam-augeasproviders_ssh",
-  "version": "2.2.2",
+  "version": "2.5.0",
   "author": "Dominic Cleal, Raphael Pinson",
   "summary": "Augeas-based ssh types and providers for Puppet",
   "license": "Apache-2.0",

--- a/spec/fixtures/unit/puppet/provider/ssh_config/augeas/full
+++ b/spec/fixtures/unit/puppet/provider/ssh_config/augeas/full
@@ -49,6 +49,7 @@ Host *
 #   ProxyCommand ssh -q -W %h:%p gateway.example.com
 #   RekeyLimit 1G 1h
     SendEnv LANG LC_*
+    SendEnv QUX
     HashKnownHosts yes
     GSSAPIAuthentication yes
     GSSAPIDelegateCredentials no

--- a/spec/fixtures/unit/puppet/provider/sshd_config/augeas/broken
+++ b/spec/fixtures/unit/puppet/provider/sshd_config/augeas/broken
@@ -84,8 +84,8 @@ GSSAPICleanupCredentials yes
 #GSSAPIStrictAcceptorCheck yes
 #GSSAPIKeyExchange no
 
-# Set this to 'yes' to enable PAM authentication, account processing,
-# and session processing. If this is enabled, PAM authentication will
+# Set this to 'yes' to enable PAM authentication, account processing, 
+# and session processing. If this is enabled, PAM authentication will 
 # be allowed through the ChallengeResponseAuthentication and
 # PasswordAuthentication.  Depending on your PAM configuration,
 # PAM authentication via ChallengeResponseAuthentication may bypass

--- a/spec/fixtures/unit/puppet/provider/sshd_config/augeas/full
+++ b/spec/fixtures/unit/puppet/provider/sshd_config/augeas/full
@@ -83,8 +83,8 @@ GSSAPICleanupCredentials yes
 #GSSAPIStrictAcceptorCheck yes
 #GSSAPIKeyExchange no
 
-# Set this to 'yes' to enable PAM authentication, account processing,
-# and session processing. If this is enabled, PAM authentication will
+# Set this to 'yes' to enable PAM authentication, account processing, 
+# and session processing. If this is enabled, PAM authentication will 
 # be allowed through the ChallengeResponseAuthentication and
 # PasswordAuthentication.  Depending on your PAM configuration,
 # PAM authentication via ChallengeResponseAuthentication may bypass

--- a/spec/fixtures/unit/puppet/provider/sshd_config/augeas/nomatch
+++ b/spec/fixtures/unit/puppet/provider/sshd_config/augeas/nomatch
@@ -83,8 +83,8 @@ GSSAPICleanupCredentials yes
 #GSSAPIStrictAcceptorCheck yes
 #GSSAPIKeyExchange no
 
-# Set this to 'yes' to enable PAM authentication, account processing,
-# and session processing. If this is enabled, PAM authentication will
+# Set this to 'yes' to enable PAM authentication, account processing, 
+# and session processing. If this is enabled, PAM authentication will 
 # be allowed through the ChallengeResponseAuthentication and
 # PasswordAuthentication.  Depending on your PAM configuration,
 # PAM authentication via ChallengeResponseAuthentication may bypass

--- a/spec/fixtures/unit/puppet/provider/sshd_config_subsystem/augeas/broken
+++ b/spec/fixtures/unit/puppet/provider/sshd_config_subsystem/augeas/broken
@@ -84,8 +84,8 @@ GSSAPICleanupCredentials yes
 #GSSAPIStrictAcceptorCheck yes
 #GSSAPIKeyExchange no
 
-# Set this to 'yes' to enable PAM authentication, account processing,
-# and session processing. If this is enabled, PAM authentication will
+# Set this to 'yes' to enable PAM authentication, account processing, 
+# and session processing. If this is enabled, PAM authentication will 
 # be allowed through the ChallengeResponseAuthentication and
 # PasswordAuthentication.  Depending on your PAM configuration,
 # PAM authentication via ChallengeResponseAuthentication may bypass

--- a/spec/fixtures/unit/puppet/provider/sshd_config_subsystem/augeas/full
+++ b/spec/fixtures/unit/puppet/provider/sshd_config_subsystem/augeas/full
@@ -84,8 +84,8 @@ GSSAPICleanupCredentials yes
 #GSSAPIStrictAcceptorCheck yes
 #GSSAPIKeyExchange no
 
-# Set this to 'yes' to enable PAM authentication, account processing,
-# and session processing. If this is enabled, PAM authentication will
+# Set this to 'yes' to enable PAM authentication, account processing, 
+# and session processing. If this is enabled, PAM authentication will 
 # be allowed through the ChallengeResponseAuthentication and
 # PasswordAuthentication.  Depending on your PAM configuration,
 # PAM authentication via ChallengeResponseAuthentication may bypass

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,7 +34,7 @@ Puppet[:modulepath] = File.join(dir, 'fixtures', 'modules')
 # ticket https://tickets.puppetlabs.com/browse/MODULES-823
 #
 ver = Gem::Version.new(Puppet.version.split('-').first)
-if Gem::Requirement.new("~> 2.7.20") =~ ver || Gem::Requirement.new("~> 3.0.0") =~ ver || Gem::Requirement.new("~> 3.5") =~ ver
+if Gem::Requirement.new("~> 2.7.20") =~ ver || Gem::Requirement.new("~> 3.0.0") =~ ver || Gem::Requirement.new("~> 3.5") =~ ver || Gem::Requirement.new("~> 4.0") =~ ver
   puts "augeasproviders: setting Puppet[:libdir] to work around broken type autoloading"
   # libdir is only a single dir, so it can only workaround loading of one external module
   Puppet[:libdir] = "#{Puppet[:modulepath]}/augeasproviders_core/lib"

--- a/spec/unit/puppet/provider/ssh_config/augeas_spec.rb
+++ b/spec/unit/puppet/provider/ssh_config/augeas_spec.rb
@@ -135,11 +135,12 @@ describe provider_class do
         }
       }
 
-      expect(inst.size).to eq(4)
+      expect(inst.size).to eq(5)
       expect(inst[0]).to eq({:name=>"SendEnv", :ensure=>:present, :value=>["LANG", "LC_*"], :key=>"SendEnv", :host=>"*"})
-      expect(inst[1]).to eq({:name=>"HashKnownHosts", :ensure=>:present, :value=>["yes"], :key=>"HashKnownHosts", :host=>"*"})
-      expect(inst[2]).to eq({:name=>"GSSAPIAuthentication", :ensure=>:present, :value=>["yes"], :key=>"GSSAPIAuthentication", :host=>"*"})
-      expect(inst[3]).to eq({:name=>"GSSAPIDelegateCredentials", :ensure=>:present, :value=>["no"], :key=>"GSSAPIDelegateCredentials", :host=>"*"})
+      expect(inst[1]).to eq({:name=>"SendEnv", :ensure=>:present, :value=>["QUX"], :key=>"SendEnv", :host=>"*"})
+      expect(inst[2]).to eq({:name=>"HashKnownHosts", :ensure=>:present, :value=>["yes"], :key=>"HashKnownHosts", :host=>"*"})
+      expect(inst[3]).to eq({:name=>"GSSAPIAuthentication", :ensure=>:present, :value=>["yes"], :key=>"GSSAPIAuthentication", :host=>"*"})
+      expect(inst[4]).to eq({:name=>"GSSAPIDelegateCredentials", :ensure=>:present, :value=>["no"], :key=>"GSSAPIDelegateCredentials", :host=>"*"})
     end
 
     describe "when creating settings" do

--- a/spec/unit/puppet/provider/sshd_config/augeas_spec.rb
+++ b/spec/unit/puppet/provider/sshd_config/augeas_spec.rb
@@ -59,7 +59,7 @@ describe provider_class do
 
     context "when declaring two resources with same key" do
       it "should fail with same name" do
-        expect do
+        expect do 
           apply!(
             Puppet::Type.type(:sshd_config).new(
               :name      => "X11Forwarding",
@@ -79,7 +79,7 @@ describe provider_class do
       end
 
       it "should fail with different names, same key and no conditions" do
-        expect do
+        expect do 
           apply!(
             Puppet::Type.type(:sshd_config).new(
               :name      => "X11Forwarding",
@@ -99,7 +99,7 @@ describe provider_class do
       end
 
       it "should not fail with different names, same key and different conditions" do
-        expect do
+        expect do 
           apply!(
             Puppet::Type.type(:sshd_config).new(
               :name      => "X11Forwarding",
@@ -170,7 +170,7 @@ describe provider_class do
           :target    => target,
           :provider  => "augeas"
         ))
-
+  
         aug_open(target, "Sshd.lns") do |aug|
           expect(aug.match("Match[2]/Settings/ListenAddress[preceding-sibling::Port]").size).to eq(1)
         end
@@ -226,7 +226,7 @@ describe provider_class do
           :target   => target,
           :provider => "augeas"
         ))
-
+  
         aug_open(target, "Sshd.lns") do |aug|
           expect(aug.get("AllowUsers/1")).to eq("ssh")
           expect(aug.get("AllowUsers/2")).to eq("foo")
@@ -386,13 +386,13 @@ describe provider_class do
           :target   => target,
           :provider => "augeas"
         ))
-
+  
         aug_open(target, "Sshd.lns") do |aug|
           expect(aug.match("*[label()=~regexp('PasswordAuthentication', 'i')]").size).to eq(1)
           expect(aug.get("PasswordAuthentication")).to eq("no")
         end
       end
-
+  
       it "should not replace settings case insensitively when on Augeas < 1.0.0" do
         provider_class.stubs(:supported?).with(:post_resource_eval)
         provider_class.stubs(:supported?).with(:regexpi).returns(false)
@@ -402,7 +402,7 @@ describe provider_class do
           :target   => target,
           :provider => "augeas"
         ))
-
+  
         aug_open(target, "Sshd.lns") do |aug|
           expect(aug.match("GSSAPIAuthentication").size).to eq(1)
           expect(aug.match("GSSAPIauthentIcAtion").size).to eq(1)

--- a/spec/unit/puppet/provider/sshkey/augeas_spec.rb
+++ b/spec/unit/puppet/provider/sshkey/augeas_spec.rb
@@ -91,6 +91,21 @@ describe provider_class do
     let(:tmptarget) { aug_fixture("full") }
     let(:target) { tmptarget.path }
 
+    it "should list instances" do
+      provider_class.stubs(:target).returns(target)
+      inst = provider_class.instances.map { |p|
+        {
+          :name         => p.get(:name),
+          :type         => p.get(:type),
+          :key          => p.get(:key),
+          :host_aliases => p.get(:host_aliases)
+        }
+      }
+
+      expect(inst.size).to eq(1)
+      expect(inst[0]).to eq({:name=>"foo.example.com", :type=>"ssh-rsa", :key=>"AAAAB3NzaC1yc2EAAAADAQABAAABAQDl1Lw2S7Vgl36/TfP+oeHsoPei1UEl9E8DO2KmSLcf+8HFxPMd/9K0gJwJHKLdNBPwpi/YTsgY0hY7JmrWaZzv6CmrfKTYr/xpCP0yF6hKTv/2JX499CH4Q8rx2mqvI8jI/aQhtRSgWolNMc84jLMwdborGMWGXpIGuneF/hn9BkMTCCWSig8MYcR2IAHzb4rpva3wqH/RpczWRuEtCBPkcvoCFrdBbkpFNSihexIM+y1MPq2a18qA2IcCwl/KUfip16tyrCWkr7tMNBbjx6b1EDurlUX75Gk8KuOVNZcjdgYNQLAC+JeYQkynYz/0hQMBZaHDPrHjhz62WFNdGC+B", :host_aliases=>["foo"]})
+    end
+
     it "should modify clear value" do
       apply!(Puppet::Type.type(:sshkey).new(
         :name     => "foo.example.com",


### PR DESCRIPTION
The last update retained our patches to the augeasproviders_ssh code to
work around some issues.

These issues appear to be fixed in the 2.5.0 release so we needed to
update our branch to incorporate the proper fix stack.

SIMP-335 #comment Proper update to the vendor 2.5.0 version
